### PR TITLE
fix: Github filters ignore the time and focus only on the date

### DIFF
--- a/src/workflows/download-github-reports.js
+++ b/src/workflows/download-github-reports.js
@@ -29,8 +29,8 @@ const collectGithubReport = async ({ start, end }) => {
   repos.forEach(repo => {
     const rangeStart = new Date(start)
     const rangeEnd = new Date(end)
-    const createdAt = new Date(repo.created_at)
-    const pushedAt = new Date(repo.pushed_at)
+    const createdAt = new Date(repo.created_at.split('T')[0])
+    const pushedAt = new Date(repo.pushed_at.split('T')[0])
 
     if (createdAt >= rangeStart) {
       newRepos.push(repo)
@@ -57,7 +57,7 @@ const collectGithubReport = async ({ start, end }) => {
     .filter(release => {
       if (!release) return false
 
-      const published = new Date(release.published_at)
+      const published = new Date(release.published_at.split('T')[0])
       const rangeStart = new Date(start)
       const rangeEnd = new Date(end)
       return published >= rangeStart && published <= rangeEnd


### PR DESCRIPTION
## Description

Github filters ignore the time and focus only on the date

## Related Issue

N/A

## Motivation and Context

If the report is generated in the same date as a release should be included in the report.

## How Has This Been Tested?

Tests are passing, confirmed in local development

## Screenshots (if appropriate):

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
